### PR TITLE
URL tweaks for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "displayName": "Functional Genomics",
   "description": "Extensions for bioinformatics and computational biology",
   "publisher": "FunctionalGenomics",
-  "repository": " Functional-Genomics-Lab/functional-genomics-extension-pack",
-  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/Functional-Genomics-Lab/functional-genomics-extension-pack"
+  },
+  "bugs": {
+    "url": "https://github.com/Functional-Genomics-Lab/functional-genomics-extension-pack/issues"
+  },
+  "homepage": "https://taehoonkim.org/",
+  "version": "0.1.1",
   "icon": "logo.jpeg",
   "engines": {
     "vscode": "^1.53.0"


### PR DESCRIPTION
The repository URL was broken due to some whitespace in the JSON, giving https://github.com/%20Functional-Genomics-Lab/functional-genomics-extension-pack.git

Updated with a couple of tweaks based on what @Emiller88 wrote in https://github.com/nf-core/vscode-extensionpack/blob/master/package.json